### PR TITLE
Fix <pre> being off center

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -1,7 +1,7 @@
 pre {
   display: block;
   width: 80%;
-  margin-left: 10%;
+  margin: 0 auto;
   background-color: transparent;
   background: rgba(200, 200, 200, 0.04);
   padding: 0.5em;


### PR DESCRIPTION
`<pre>` is off center because while you have `width: 80%` and `margin-left: 10%`, the padding `padding: 0.5em` makes the actual width larger than 80%

https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing

![screenshot showing pre being off center](https://github.com/user-attachments/assets/26519ea9-d0dd-4bb3-a8ec-a6631e7d22ca)
