### PR TITLE
Add support for furigana

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -15,3 +15,7 @@ enable = true
 
 [output.html.search]
 use-boolean-and = true   # multiple search terms combined with AND opposed to OR
+
+[preprocessor.furigana]
+command = "python scripts/preprocess-furigana.py"
+renderers = ["html"]

--- a/scripts/preprocess-furigana.py
+++ b/scripts/preprocess-furigana.py
@@ -1,0 +1,38 @@
+import json
+import re
+import sys
+
+# if hasattr(sys.stdin, "reconfigure"):
+#     sys.stdin.reconfigure(encoding="utf-8")
+# if hasattr(sys.stdout, "reconfigure"):
+#     sys.stdout.reconfigure(encoding="utf-8")
+
+
+def furi_replace(text):
+    # ex format: {f|翌|よく}{f|日|び}
+    return re.sub(r"\{f\|([^{}|\n]+)\|([^{}|\n]+)\}", r"<ruby>\1<rt>\2</rt></ruby>", text)
+
+
+def process_chapters(items):
+    for item in items:
+        if "Chapter" in item:
+            chapter = item["Chapter"]
+            chapter["content"] = furi_replace(chapter["content"])
+            process_chapters(chapter.get("sub_items", []))
+
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "supports":
+        sys.exit(0)
+
+    try:
+        _, book = json.load(sys.stdin)
+        process_chapters(book.get("items", []))
+        json.dump(book, sys.stdout, ensure_ascii=False)
+    except Exception:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preprocess-furigana.py
+++ b/scripts/preprocess-furigana.py
@@ -2,11 +2,6 @@ import json
 import re
 import sys
 
-# if hasattr(sys.stdin, "reconfigure"):
-#     sys.stdin.reconfigure(encoding="utf-8")
-# if hasattr(sys.stdout, "reconfigure"):
-#     sys.stdout.reconfigure(encoding="utf-8")
-
 
 def furi_replace(text):
     # ex format: {f|翌|よく}{f|日|び}

--- a/src/Section2/Part3/Lesson35.md
+++ b/src/Section2/Part3/Lesson35.md
@@ -1,6 +1,6 @@
 # Generic nouns and nominalization with 事, 物, ところ, and の
 
-事(こと) and 物(もの) both mean "thing". 事 is generally used for intangible things like actions or states, and 物 is generally used for tangible things like objects. Grammatically, they are nouns, so just like any other noun they can be modified by verbs and adjectives.
+{f|事|こと} and {f|物|もの} both mean "thing". 事 is generally used for intangible things like actions or states, and 物 is generally used for tangible things like objects. Grammatically, they are nouns, so just like any other noun they can be modified by verbs and adjectives.
 
 <pre>
 あ、いい<b>こと</b>考えた
@@ -10,7 +10,7 @@ Ah, I just thought about something good
 I want to eat something tasty
 </pre>
 
-所(ところ) is a word that means "place". It is used in similar patterns, including ones about intangible places like moments in time or progress, and aspects of an entity. It is often contracted to とこ. 
+{f|所|ところ} is a word that means "place". It is used in similar patterns, including ones about intangible places like moments in time or progress, and aspects of an entity. It is often contracted to とこ. 
 
 <pre>
 ちょうどいい<b>ところ</b>に来ました。

--- a/src/Section2/Part4.md
+++ b/src/Section2/Part4.md
@@ -1,5 +1,5 @@
 # Part 4: Adding Spices and "The Rest"
 
-七味(しちみ) is called like that because it is seven (七) spice flavors (味). It's neither six nor eight. It's exactly seven. We want to spice up our Japanese flavor, and we will do it juuuuust right. In this part we'll bring everything to a close and learn to appreciate the flavorful palate of the Japanese language.
+{f|七味|しちみ} is called like that because it is seven (七) spice flavors (味). It's neither six nor eight. It's exactly seven. We want to spice up our Japanese flavor, and we will do it juuuuust right. In this part we'll bring everything to a close and learn to appreciate the flavorful palate of the Japanese language.
 
 And some of the remaining pieces too.


### PR DESCRIPTION
Add support for proper furigana display. For example, `{f|七味|しちみ}` produces this:

<img width="69" height="76" alt="image" src="https://github.com/user-attachments/assets/cd8fff8a-5099-4420-8a02-a24399ca2bd8" />

There's only a few places in the book right now where furigana is included in parentheses in the book right now, which I've replaced with proper furigana, but this could be utilized more in the future (especially for iOS users who can't use Yomitan).